### PR TITLE
Issue 6: Adding PWA and AMP Compatibility

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -21,7 +21,7 @@
 
 	<!-- Rules: Check PHP version compatibility -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.3-"/>
+	<config name="testVersion" value="7.2-"/>
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
 
@@ -41,7 +41,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<!-- Value: replace the text domain used. -->
-			<property name="text_domain" type="array" value="perfecty-push"/>
+			<property name="text_domain" type="array" value="perfecty-push-notifications"/>
 		</properties>
 	</rule>
 	<rule ref="WordPress.WhiteSpace.ControlStructureSpacing">

--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -773,7 +773,7 @@ class Perfecty_Push_Admin {
 	 */
 	public function print_service_worker_scope() {
 		$options = get_option( 'perfecty_push' );
-		$value   = isset( $options['service_worker_scope'] ) ? esc_attr( $options['service_worker_scope'] ) : '/perfecty/push';
+		$value   = isset( $options['service_worker_scope'] ) ? esc_attr( $options['service_worker_scope'] ) : '';
 
 		printf(
 			'<input type="text" id="perfecty_push[service_worker_scope]"' .

--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -405,11 +405,11 @@ class Perfecty_Push_Admin {
 			$message = $notice['message'];
 
 			if ( $type === 'warning' ) {
-				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', esc_html( $message ) );
+				printf( '<div class="notice notice-warning is-dismissible"><p>%s</p></div>', $message );
 			} elseif ( $type === 'error' ) {
-				printf( '<div class="notice notice-error is-dismissible"><p>%s</p></div>', esc_html( $message ) );
+				printf( '<div class="notice notice-error is-dismissible"><p>%s</p></div>', $message );
 			} else {
-				printf( '<div class="notice notice-success is-dismissible"><p>%s</p></div>', esc_html( $message ) );
+				printf( '<div class="notice notice-success is-dismissible"><p>%s</p></div>', $message );
 			}
 
 			delete_transient( 'perfecty_push_admin_notice' );

--- a/admin/class-perfecty-push-admin.php
+++ b/admin/class-perfecty-push-admin.php
@@ -203,6 +203,14 @@ class Perfecty_Push_Admin {
 		);
 
 		add_settings_field(
+			'service_worker_scope', // id
+			esc_html__( 'Service Worker Scope', 'perfecty-push-notifications' ), // title
+			array( $this, 'print_service_worker_scope' ), // callback
+			'perfecty-push-options', // page
+			'perfecty_push_widget_settings' // section
+		);
+
+		add_settings_field(
 			'dialog_title', // id
 			esc_html__( 'Subscribe text', 'perfecty-push-notifications' ), // title
 			array( $this, 'print_dialog_title' ), // callback
@@ -602,6 +610,9 @@ class Perfecty_Push_Admin {
 		}
 
 		// text
+		if ( isset( $input['service_worker_scope'] ) ) {
+			$new_input['service_worker_scope'] = sanitize_text_field( $input['service_worker_scope'] );
+		}
 		if ( isset( $input['dialog_title'] ) ) {
 			$new_input['dialog_title'] = sanitize_text_field( $input['dialog_title'] );
 		}
@@ -752,6 +763,22 @@ class Perfecty_Push_Admin {
 			'<input type="checkbox" id="perfecty_push[unregister_conflicts]"' .
 			'name="perfecty_push[unregister_conflicts]" %s />',
 			esc_html( $enabled )
+		);
+	}
+
+	/**
+	 * Print the service_worker_scope option
+	 *
+	 * @since 1.0.7
+	 */
+	public function print_service_worker_scope() {
+		$options = get_option( 'perfecty_push' );
+		$value   = isset( $options['service_worker_scope'] ) ? esc_attr( $options['service_worker_scope'] ) : '/perfecty/push';
+
+		printf(
+			'<input type="text" id="perfecty_push[service_worker_scope]"' .
+			'name="perfecty_push[service_worker_scope]" value="%s" />',
+			esc_html( $value )
 		);
 	}
 

--- a/admin/partials/perfecty-push-admin-about.php
+++ b/admin/partials/perfecty-push-admin-about.php
@@ -71,8 +71,20 @@
 		printf(
 			// translators: %1$s is the opening a tag
 			// translators: %2$s is the closing a tag
-			esc_html__( 'Optionally you can %1$s send me %2$s a message.', 'perfecty-push-notifications' ),
+			esc_html__( 'Optionally you can %1$s send me%2$s a message.', 'perfecty-push-notifications' ),
 			'<a href="https://rowinson.netlify.app/contact/" target="_blank">',
+			'</a>'
+		);
+		?>
+	</p>
+	<h2><?php printf( esc_html__( 'Follow us', 'perfecty-push-notifications' ) ); ?></h2>
+	<p>
+		<?php
+		printf(
+		// translators: %1$s is the opening a tag
+		// translators: %2$s is the closing a tag
+			esc_html__( 'Follow us on %1$s Facebook %2$s', 'perfecty-push-notifications' ),
+			'<a href="https://www.facebook.com/Perfecty-Push-109168991261513" target="_blank">',
 			'</a>'
 		);
 		?>

--- a/includes/class-perfecty-push-activator.php
+++ b/includes/class-perfecty-push-activator.php
@@ -52,6 +52,13 @@ class Perfecty_Push_Activator {
 		if ( ! isset( $options['widget_enabled'] ) ) {
 			$options['widget_enabled'] = 1;
 		}
+		if ( empty( $options['service_worker_scope'] ) && get_option( 'perfecty_push' ) !== false ) {
+			// this is before 1.0.7, please remove
+			// after 1 year has passed (today: 03-21-2021)
+			$options['service_worker_scope'] = '/';
+		} elseif ( empty( $options['service_worker_scope'] ) ) {
+			$options['service_worker_scope'] = '/perfecty/push';
+		}
 
 		if ( get_option( 'perfecty_push' ) == false ) {
 			if ( ! add_option( 'perfecty_push', $options ) ) {

--- a/includes/class-perfecty-push-activator.php
+++ b/includes/class-perfecty-push-activator.php
@@ -49,17 +49,12 @@ class Perfecty_Push_Activator {
 		if ( empty( $options['batch_size'] ) ) {
 			$options['batch_size'] = Perfecty_Push_Lib_Push_Server::DEFAULT_BATCH_SIZE;
 		}
+		if ( empty( $options['service_worker_scope'] ) ) {
+			$options['service_worker_scope'] = '/perfecty/push';
+		}
 		if ( ! isset( $options['widget_enabled'] ) ) {
 			$options['widget_enabled'] = 1;
 		}
-		if ( empty( $options['service_worker_scope'] ) && get_option( 'perfecty_push' ) !== false ) {
-			// this is before 1.0.7, please remove
-			// after 1 year has passed (today: 03-21-2021)
-			$options['service_worker_scope'] = '/';
-		} elseif ( empty( $options['service_worker_scope'] ) ) {
-			$options['service_worker_scope'] = '/perfecty/push';
-		}
-
 		if ( get_option( 'perfecty_push' ) == false ) {
 			if ( ! add_option( 'perfecty_push', $options ) ) {
 				error_log( 'Could not set the default options' );

--- a/includes/class-perfecty-push-global.php
+++ b/includes/class-perfecty-push-global.php
@@ -43,12 +43,14 @@ class Perfecty_Push_Global {
 
 		if ( get_option( 'perfecty_push_version' ) != PERFECTY_PUSH_VERSION ) {
 			// upgrade options
-			$options = get_option( 'perfecty_push', array() );
-			if ( $plugin_activated == 1 && ! isset( $options['service_worker_scope'] ) ) {
-				// this is before 1.0.7
-				$options['service_worker_scope'] = '/';
+			if ( $plugin_activated == 1 ) {
+				$options = get_option( 'perfecty_push', array() );
+				if ( ! isset( $options['service_worker_scope'] ) ) {
+					// this is before 1.0.7
+					$options['service_worker_scope'] = '/';
+					update_option( 'perfecty_push', $options );
+				}
 			}
-			update_option( 'perfecty_push', $options );
 			update_option( 'perfecty_push_version', PERFECTY_PUSH_VERSION );
 		}
 		if ( get_option( 'perfecty_push_db_version' ) != PERFECTY_PUSH_DB_VERSION ) {

--- a/includes/class-perfecty-push-global.php
+++ b/includes/class-perfecty-push-global.php
@@ -27,21 +27,32 @@
 class Perfecty_Push_Global {
 
 	/**
-	 * Performs a check of the DB structure and the version to run DB upgrades.
+	 * Performs a check of the DB and options upgrade
 	 * This is particularly helpful when the plugin is updated
-	 * because the register_activation_hook is not called.
+	 * because the register_activation_hook is not called on upgrades.
 	 *
 	 * @since    1.0.0
 	 * @access   private
 	 */
-	public function db_upgrade_check() {
+	public function upgrade_check() {
 		$plugin_activated = get_option( 'perfecty_push_activated', 0 );
 
 		if ( $plugin_activated == 1 ) {
 			Class_Perfecty_Push_Lib_Utils::check_database();
 		}
 
+		if ( get_option( 'perfecty_push_version' ) != PERFECTY_PUSH_VERSION ) {
+			// upgrade options
+			$options = get_option( 'perfecty_push', array() );
+			if ( $plugin_activated == 1 && ! isset( $options['service_worker_scope'] ) ) {
+				// this is before 1.0.7
+				$options['service_worker_scope'] = '/';
+			}
+			update_option( 'perfecty_push', $options );
+			update_option( 'perfecty_push_version', PERFECTY_PUSH_VERSION );
+		}
 		if ( get_option( 'perfecty_push_db_version' ) != PERFECTY_PUSH_DB_VERSION ) {
+			// upgrade db
 			Perfecty_Push_Lib_Db::db_create();
 		}
 	}

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -91,14 +91,18 @@ class Perfecty_Push {
 	 * Define the constants that will be needed later
 	 */
 	public function define_constants() {
-		$options           = get_option( 'perfecty_push', array() );
-		$vapid_public_key  = isset( $options['vapid_public_key'] ) ? $options['vapid_public_key'] : '';
-		$vapid_private_key = isset( $options['vapid_private_key'] ) ? $options['vapid_private_key'] : '';
-		$server_url        = isset( $options['server_url'] ) ? $options['server_url'] : get_site_url();
+		$options              = get_option( 'perfecty_push', array() );
+		$vapid_public_key     = isset( $options['vapid_public_key'] ) ? $options['vapid_public_key'] : '';
+		$vapid_private_key    = isset( $options['vapid_private_key'] ) ? $options['vapid_private_key'] : '';
+		$server_url           = isset( $options['server_url'] ) ? $options['server_url'] : get_site_url();
+		$service_worker_scope = isset( $options['service_worker_scope'] ) && ! empty( $options['service_worker_scope'] ) ? $options['service_worker_scope'] : '/perfecty/push';
 
 		if ( ! defined( 'PERFECTY_PUSH_JS_DIR' ) ) {
 			$path = plugin_dir_url( __DIR__ ) . 'public/js';
 			define( 'PERFECTY_PUSH_JS_DIR', $path );
+		}
+		if ( ! defined( 'PERFECTY_PUSH_SERVICE_WORKER_SCOPE' ) ) {
+			define( 'PERFECTY_PUSH_SERVICE_WORKER_SCOPE', $service_worker_scope );
 		}
 		if ( ! defined( 'PERFECTY_PUSH_SERVER_URL' ) ) {
 			define( 'PERFECTY_PUSH_SERVER_URL', $server_url );

--- a/includes/class-perfecty-push.php
+++ b/includes/class-perfecty-push.php
@@ -252,7 +252,7 @@ class Perfecty_Push {
 	 */
 	private function define_global_hooks() {
 		$global = new Perfecty_Push_Global();
-		$this->loader->add_action( 'plugins_loaded', $global, 'db_upgrade_check' );
+		$this->loader->add_action( 'plugins_loaded', $global, 'upgrade_check' );
 	}
 
 	/**

--- a/lib/class-perfecty-push-lib-db.php
+++ b/lib/class-perfecty-push-lib-db.php
@@ -48,7 +48,7 @@ class Perfecty_Push_Lib_Db {
           id int(11) NOT NULL AUTO_INCREMENT,
           uuid char(36) NOT NULL,
           remote_ip varchar(46) DEFAULT '',
-          endpoint varchar(500) NOT NULL UNIQUE,
+          endpoint varchar(500) NOT NULL,
           key_auth varchar(100) NOT NULL UNIQUE,
           key_p256dh varchar(100) NOT NULL UNIQUE,
           is_active tinyint(1) DEFAULT 1 NOT NULL,
@@ -79,6 +79,9 @@ class Perfecty_Push_Lib_Db {
 				// manual: dbDelta doesn't drop indexes
 				if ( $wpdb->get_var( "SHOW INDEX FROM $user_table WHERE Key_name='users_endpoint_uk'" ) !== null ) {
 					$wpdb->query( "ALTER TABLE $user_table DROP INDEX users_endpoint_uk" );
+				}
+				if ( $wpdb->get_var( "SHOW INDEX FROM $user_table WHERE Key_name='endpoint'" ) !== null ) {
+					$wpdb->query( "ALTER TABLE $user_table DROP INDEX endpoint" );
 				}
 			}
 

--- a/public/class-perfecty-push-users.php
+++ b/public/class-perfecty-push-users.php
@@ -1,7 +1,4 @@
 <?php
-
-use Ramsey\Uuid\Uuid;
-
 /**
  * The public-facing functionality of the plugin.
  *
@@ -19,6 +16,9 @@ use Ramsey\Uuid\Uuid;
  * @subpackage Perfecty_Push/public
  * @author     Rowinson Gallego <rwn.gallego@gmail.com>
  */
+
+use Ramsey\Uuid\Uuid;
+
 class Perfecty_Push_Users {
 	/**
 	 * Register the user
@@ -29,10 +29,10 @@ class Perfecty_Push_Users {
 		// Request
 		$user      = $data['user'] ?? null;
 		$user_id   = $data['user_id'] ?? null;
-		$remote_ip = $_SERVER['REMOTE_ADDR'];
+		$remote_ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
 
 		// Validate the nonce
-		$nonce = isset( $_SERVER['HTTP_X_WP_NONCE'] ) ? $_SERVER['HTTP_X_WP_NONCE'] : '';
+		$nonce = isset( $_SERVER['HTTP_X_WP_NONCE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WP_NONCE'] ) ) : '';
 		if ( wp_verify_nonce( $nonce, 'wp_rest' ) === false ) {
 			$this->terminate();
 		}
@@ -93,8 +93,8 @@ class Perfecty_Push_Users {
 		$is_active = $data['is_active'] ?? null;
 		$user_id   = $data['user_id'] ?? null;
 
-		// Validate the nonce
-		$nonce = isset( $_SERVER['HTTP_X_WP_NONCE'] ) ? $_SERVER['HTTP_X_WP_NONCE'] : '';
+		// Validate the nonce.
+		$nonce = isset( $_SERVER['HTTP_X_WP_NONCE'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_WP_NONCE'] ) ) : '';
 		if ( wp_verify_nonce( $nonce, 'wp_rest' ) === false ) {
 			$this->terminate();
 		}
@@ -165,10 +165,10 @@ class Perfecty_Push_Users {
 	}
 
 	private function validate_set_user_active( $is_active, $user_id ) {
-		if ( $is_active === null || $user_id === null ) {
+		if ( null === $is_active || null === $user_id ) {
 			return __( 'Missing parameters', 'perfecty-push-notifications' );
 		}
-		if ( $is_active != false && $is_active != true ) {
+		if ( false !== $is_active && true !== $is_active ) {
 			return __( 'is_active must be a boolean', 'perfecty-push-notifications' );
 		}
 		if ( ! Uuid::isValid( $user_id ) ) {

--- a/public/class-perfecty-push-users.php
+++ b/public/class-perfecty-push-users.php
@@ -55,9 +55,11 @@ class Perfecty_Push_Users {
 
 			$user = Perfecty_Push_Lib_Db::get_user_by_uuid( $user_id );
 			if ( $user ) {
+				$user->endpoint   = $endpoint;
 				$user->key_auth   = $key_auth;
 				$user->key_p256dh = $key_p256dh;
 				$user->remote_ip  = $remote_ip;
+				$user->disabled   = false;
 				$result           = Perfecty_Push_Lib_Db::update_user( $user );
 				if ( $result === false ) {
 					// Could not update the user

--- a/public/js/perfecty-push-public.js
+++ b/public/js/perfecty-push-public.js
@@ -195,22 +195,32 @@ function setUserActive(nonce, siteUrl, userId, isActive) {
 function detectConflictInstallations(scope, unregisterConflicts) {
     let conflictDetected = false
     let perfectyPushFound = false
-    return navigator.serviceWorker.getRegistration(scope).then(function (registration) {
+    let oldInstall = false
+    return navigator.serviceWorker.getRegistrations().then(function (registrations) {
+        const fullScope = window.location.origin + scope
         let promises = []
-        if (typeof registration !== "undefined" && registration.active != null && registration.active.scriptURL != null) {
-            if (/perfecty/i.test(registration.active.scriptURL)) {
-                perfectyPushFound = true
-            } else {
-                conflictDetected = true
+        for (let registration of registrations) {
+            if (typeof registration !== "undefined" && registration.active != null && registration.active.scriptURL != null) {
+                if (/perfecty\-push/i.test(registration.active.scriptURL)) {
+                    perfectyPushFound = true
 
-                if (unregisterConflicts === true) {
-                    console.log(__('Unregistering conflict installation: ', 'perfecty-push-notifications' ) + registration.active.scriptURL)
-                    promises.push(registration.unregister())
+                    if (registration.scope !== fullScope) {
+                        oldInstall = true
+                        console.log(__('Unregistering old installation: ', 'perfecty-push-notifications') + registration.scope)
+                        promises.push(registration.unregister())
+                    }
+                } else {
+                    conflictDetected = true
+
+                    if (unregisterConflicts === true) {
+                        console.log(__('Unregistering conflict installation: ', 'perfecty-push-notifications') + registration.active.scriptURL)
+                        promises.push(registration.unregister())
+                    }
                 }
             }
         }
         return Promise.all(promises).then(() => {
-            return Promise.resolve([conflictDetected, perfectyPushFound])
+            return Promise.resolve([conflictDetected, perfectyPushFound, oldInstall])
         })
     });
 }
@@ -228,9 +238,9 @@ async function perfectyStart(options) {
             showDialogControl();
         } else if (permission === 'granted') {
             // as we already have 'granted' permissions, we check if it was an external worker
-            detectConflictInstallations(options.serviceWorkerScope, options.unregisterConflicts).then(([conflictDetected, perfectyPushFound]) => {
-                if ((conflictDetected && options.unregisterConflicts) || !perfectyPushFound) {
-                    // we didn't find our worker or we removed an external worker
+            detectConflictInstallations(options.serviceWorkerScope, options.unregisterConflicts).then(([conflictDetected, perfectyPushFound, oldInstall]) => {
+                if ((conflictDetected && options.unregisterConflicts) || !perfectyPushFound || oldInstall) {
+                    // we didn't find our worker, it was an old install, or we removed an external worker
                     // so we register ours again
                     registerServiceWorker(options.path, options.serviceWorkerScope, options.siteUrl, options.vapidPublicKey, options.nonce);
                 }

--- a/public/js/perfecty-push-public.js
+++ b/public/js/perfecty-push-public.js
@@ -5,10 +5,8 @@ function checkFeatures() {
     return ('serviceWorker' in navigator) && ('PushManager' in window);
 }
 
-function registerServiceWorker(path, siteUrl, vapidPublicKey64, nonce) {
-    navigator.serviceWorker.register(path + '/service-worker-loader.js.php', {scope: '/'}).then(() => {
-        return navigator.serviceWorker.ready
-    }).then(async (registration) => {
+function registerServiceWorker(path, scope, siteUrl, vapidPublicKey64, nonce) {
+    navigator.serviceWorker.register(path + '/service-worker-loader.js.php', {scope: scope}).then(async (registration) => {
         // we get the push user
         const user = await registration.pushManager.getSubscription();
         if (user) {
@@ -194,10 +192,10 @@ function setUserActive(nonce, siteUrl, userId, isActive) {
         });
 }
 
-function detectConflictInstallations(unregisterConflicts) {
+function detectConflictInstallations(scope, unregisterConflicts) {
     let conflictDetected = false
     let perfectyPushFound = false
-    return navigator.serviceWorker.getRegistration("/").then(function (registration) {
+    return navigator.serviceWorker.getRegistration(scope).then(function (registration) {
         let promises = []
         if (typeof registration !== "undefined" && registration.active != null && registration.active.scriptURL != null) {
             if (/perfecty/i.test(registration.active.scriptURL)) {
@@ -230,11 +228,11 @@ async function perfectyStart(options) {
             showDialogControl();
         } else if (permission === 'granted') {
             // as we already have 'granted' permissions, we check if it was an external worker
-            detectConflictInstallations(options.unregisterConflicts).then(([conflictDetected, perfectyPushFound]) => {
+            detectConflictInstallations(options.serviceWorkerScope, options.unregisterConflicts).then(([conflictDetected, perfectyPushFound]) => {
                 if ((conflictDetected && options.unregisterConflicts) || !perfectyPushFound) {
                     // we didn't find our worker or we removed an external worker
                     // so we register ours again
-                    registerServiceWorker(options.path, options.siteUrl, options.vapidPublicKey, options.nonce);
+                    registerServiceWorker(options.path, options.serviceWorkerScope, options.siteUrl, options.vapidPublicKey, options.nonce);
                 }
             })
         }
@@ -246,7 +244,7 @@ async function perfectyStart(options) {
             if (permission === 'granted') {
                 // We only register the service worker and the push manager
                 // when the user has granted us permissions or if there's already existing installs
-                registerServiceWorker(options.path, options.siteUrl, options.vapidPublicKey, options.nonce);
+                registerServiceWorker(options.path, options.serviceWorkerScope, options.siteUrl, options.vapidPublicKey, options.nonce);
             } else {
                 console.log(__('Notification permission not granted', 'perfecty-push-notifications' ))
             }

--- a/public/partials/perfecty-push-public-head.php
+++ b/public/partials/perfecty-push-public-head.php
@@ -38,5 +38,6 @@ if ( isset( $options['unregister_conflicts'] ) && $options['unregister_conflicts
 		nonce: "<?php echo $perfecty_push_nonce; ?>",
 		disabled: <?php echo $perfecty_push_disabled; ?>,
 		unregisterConflicts: <?php echo $perfecty_push_unregister_conflicts; ?>,
+		serviceWorkerScope: "<?php echo PERFECTY_PUSH_SERVICE_WORKER_SCOPE; ?>",
 	}
 </script>


### PR DESCRIPTION
Fixes #6 

Adding the new "Service Worker Scope" option. We are using a fake scope by default to don't take control over the root scope. However we are compatible with versions older than 1.0.7 and for those we still use the "/" scope.